### PR TITLE
add sphinx and sphinx argparse plugin back to requirements-docs.txt

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -6,3 +6,5 @@ paramiko==1.15.2
 crypto==1.3.4
 boltons==0.6.3
 peewee==2.6.0
+Sphinx==1.2.3
+sphinx-argparse==0.1.14


### PR DESCRIPTION
Fixes doc builds in ReadTheDocs

http://broad-cms.readthedocs.io/
