### PR TITLE
when encoding tpeds from VCF input, skip loci that incorrectly encode unknown genotypes

### DIFF
--- a/cms/tools/selscan.py
+++ b/cms/tools/selscan.py
@@ -220,7 +220,15 @@ class SelscanFormatter(object):
                             if chromosome_num.upper() != "X":
                                 try:
                                     genotypes_for_selected_samples = operator.itemgetter(*indices_of_matching_genotypes)(genos)
+                                except IndexError:
+                                    # if something about this locus makes the genotype line incomplete
+                                    # we can continue to the next record. This can happen if '.' is incorrectly used in place of '.|.' in phased VCFs.
+                                    # anything that causes the genotype line length to mismatch with the number of genotypes
+                                    print("\ngenotype line length appears to be off:")
+                                    print(record)
+                                    continue
                                 except Exception: # if this is a record of mixed ploidy, that is to say the X chromosome
+                                    # raise an exception
                                     raise
                             else:
                                 matching_genotypes = np.array(record[:len(record)])[indices_of_matching_samples]


### PR DESCRIPTION
Sometimes uncalled genotypes are represented per-sample as ‘.’, when they should be ‘.|.’ for phased haploid genomes. Per the VCF spec: “If a call cannot be made for a sample at a given locus, ‘.’ should be specified for each missing allele in the GT field (for example ‘./.’ for a diploid genotype and ‘.’ for haploid genotype).” This change skips such lines since we can’t know anything about the loci anyway, and continues encoding the other lines in the file.
