### PR TITLE
spaces -> tabs

### DIFF
--- a/cms/model/plot_func.py
+++ b/cms/model/plot_func.py
@@ -23,9 +23,9 @@ def plot_comparison(statfilename, numReps, stats =['pi', 'sfs', 'anc', 'fst', 'r
 
 	popPairs = []
 	for i in range(len(pops)):
-	    for j in range(i+1, len(pops)):
-    	    popPair = (pops[i], pops[j])
-        	popPairs.append(popPair)
+		for j in range(i+1, len(pops)):
+			popPair = (pops[i], pops[j])
+			popPairs.append(popPair)
 
 	for stat in stats:
 


### PR DESCRIPTION
python files should use either spaces or tabs for indentation, but a mixture causes issues. This is an attempt to get the docs to build.
